### PR TITLE
support tls-sni-01 challenge

### DIFF
--- a/lib/servers.js
+++ b/lib/servers.js
@@ -25,7 +25,7 @@ module.exports.create = function (challenge) {
   , startServers: function (plainPorts, tlsPorts, opts) {
       opts = opts || {};
 
-      var httpsOptions = require('localhost.daplie.com-certificates');
+      var httpsOptions = opts.httpsOptions || require('localhost.daplie.com-certificates');
       var https = require('https');
       var http = require('http');
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "homedir": "^0.6.0",
     "le-acme-core": "^2.0.5",
     "le-challenge-manual": "^2.0.0",
+    "le-challenge-sni": "^2.0.0",
     "le-challenge-standalone": "^2.0.0",
     "le-store-certbot": "^2.0.2",
     "letsencrypt": "^2.1.2",


### PR DESCRIPTION
Another update to properly support tls-sni-01 challenges. Previously the http-01 challenge was simply served over SSL. See most importantly https://github.com/Daplie/le-sni-auto/pull/2 which facilitates this (via my module `le-challenge-sni`).

This module doesn't have any tests, which is hard to do anyway since it interacts with an external server, so I didn't add any. I did, however, check it works (with the staging server).